### PR TITLE
feat: add open positions block on How We Work page

### DIFF
--- a/src/components/Blocks/OpenPositionsBlock.tsx
+++ b/src/components/Blocks/OpenPositionsBlock.tsx
@@ -1,0 +1,95 @@
+import * as React from 'react'
+import Fade from 'react-reveal/Fade'
+import { HowWeWorkPageQuery } from '../../../typings/iteamse'
+import { OPEN_POSITION_PAGE_QUERY } from '../../pages/OpenPosition'
+import styled from '../../theme'
+import GridColumn from '../Grid/GridColumn'
+import PaddedRow from '../Grid/PaddedRow'
+import StyledPrefetchLink from '../Link/StyledPrefetchLink'
+import UnstyledList from '../List/UnstyledList'
+import H3 from '../Typography/H3'
+import H4 from '../Typography/H4'
+import Paragraph from '../Typography/Paragraph'
+
+interface OpenPositionsBlockProps {
+  'data-test'?: string
+  openApplicationHeader: string
+  openApplicationText: string
+  openpositions: HowWeWorkPageQuery['openpositions']
+  title: string
+}
+
+const ColoredGridColumn = GridColumn.extend`
+  background-color: ${({ theme }) => theme.colors.concrete};
+`
+
+const Content = styled.div`
+  display: grid;
+  grid-row-gap: 20px;
+
+  @media (min-width: 1025px) {
+    grid-column-gap: 60px;
+    grid-template-columns: repeat(2, 1fr);
+    grid-row-gap: 0;
+  }
+`
+
+const SideWrap = styled.div``
+
+const UnstyledListWithMargin = UnstyledList.extend`
+  margin-top: 10px;
+`
+
+const ParagraphWrap = styled.div`
+  margin-top: 20px;
+`
+
+const OpenPosition = styled.li`
+  line-height: 44px;
+`
+
+const OpenPositionsBlock: React.SFC<OpenPositionsBlockProps> = ({
+  'data-test': dataTest = '',
+  openApplicationHeader,
+  openApplicationText,
+  openpositions,
+  title,
+}) => {
+  return (
+    <Fade bottom distance="50px">
+      <ColoredGridColumn>
+        <PaddedRow data-test={`block-${dataTest}`}>
+          <Content>
+            <SideWrap>
+              <H3>{title}</H3>
+              <UnstyledListWithMargin>
+                {openpositions.map(position => (
+                  <OpenPosition key={position.id}>
+                    <StyledPrefetchLink
+                      query={OPEN_POSITION_PAGE_QUERY}
+                      to={`/jobba-hos-oss/${position.id}`}
+                      variables={{
+                        id: position.id,
+                      }}
+                    >
+                      {position.title}
+                    </StyledPrefetchLink>{' '}
+                    ({position.location})
+                  </OpenPosition>
+                ))}
+              </UnstyledListWithMargin>
+            </SideWrap>
+            <SideWrap>
+              <H4>{openApplicationHeader}</H4>
+              <ParagraphWrap>
+                <Paragraph>{openApplicationText}</Paragraph>
+              </ParagraphWrap>
+            </SideWrap>
+          </Content>
+        </PaddedRow>
+      </ColoredGridColumn>
+    </Fade>
+  )
+}
+
+export default OpenPositionsBlock

--- a/src/components/Header/__tests__/__snapshots__/Header.spec.tsx.snap
+++ b/src/components/Header/__tests__/__snapshots__/Header.spec.tsx.snap
@@ -4,85 +4,85 @@ exports[`components/Header renders Header 1`] = `
 <div>
   <div>
     <div
-      class="sc-iyvyFf dCShgY"
+      class="sc-ibxdXY kqdudt"
     >
       <div
-        class="sc-hwwEjo cPpjPY"
+        class="sc-RefOD cUUJKM"
       >
         <div
-          class="sc-jtRfpW kaiGPi"
+          class="sc-hwwEjo kwCYBu"
         >
           <a
-            class="sc-kTUwUJ ijPJJc"
+            class="sc-kPVwWT gbyGwk"
           >
             <img
-              class="sc-dqBHgY ezKxht"
+              class="sc-kfGgVZ hQFnqD"
               data-testid="logo"
               path="test-file-stub"
             />
           </a>
           <div
-            class="sc-gxMtzJ fEeBIz"
+            class="sc-esjQYD ggQuRm"
           >
             <a
-              class="sc-gzOgki dsuNbc"
+              class="sc-eXEjpC ixflbt"
               aria-current="false"
             >
               Case
             </a>
             <a
-              class="sc-gzOgki dsuNbc"
+              class="sc-eXEjpC ixflbt"
               aria-current="false"
             >
               AI
             </a>
             <a
-              class="sc-gzOgki dsuNbc"
+              class="sc-eXEjpC ixflbt"
               aria-current="false"
             >
               Metod
             </a>
             <a
-              class="sc-gzOgki dsuNbc"
+              class="sc-eXEjpC ixflbt"
               aria-current="false"
             >
               Medarbetare
             </a>
             <a
-              class="sc-gzOgki dsuNbc"
+              class="sc-eXEjpC ixflbt"
               aria-current="false"
             >
               Karriär
             </a>
             <a
-              class="sc-gzOgki dsuNbc"
+              class="sc-eXEjpC ixflbt"
               aria-current="false"
             >
               Om
             </a>
             <a
-              class="sc-gzOgki dsuNbc"
+              class="sc-eXEjpC ixflbt"
               aria-current="false"
             >
               Drift & Support
             </a>
             <div
-              class="sc-dfVpRl foeOrh"
+              class="sc-kIPQKe gwDbIr"
             />
           </div>
         </div>
         <div
-          class="sc-kPVwWT iEyyyl"
+          class="sc-iQKALj eHHGjm"
         >
           <h1
-            class="sc-kfGgVZ gqfFed"
+            class="sc-bwCtUz hOGgNe"
           >
             <span>
               Vi digitaliserar företag och organisationer
             </span>
           </h1>
           <h1
-            class="sc-kfGgVZ gqfFed"
+            class="sc-bwCtUz hOGgNe"
           >
             <span>
               genom strategi, kod och kultur

--- a/src/components/Header/__tests__/__snapshots__/Navigation.spec.tsx.snap
+++ b/src/components/Header/__tests__/__snapshots__/Navigation.spec.tsx.snap
@@ -34,6 +34,11 @@ Object {
   "query": Array [
     "
   query HowWeWorkPage {
+    openpositions {
+      location
+      id
+      title
+    }
     pageHowWeWork {
       headerImage
       headerText1
@@ -43,6 +48,8 @@ Object {
       customersText
       customersTitle
       hiringTitle
+      openApplicationText
+      openApplicationHeader
       imageBleed
       methodText
       methodTitle

--- a/src/components/Typography/H4.tsx
+++ b/src/components/Typography/H4.tsx
@@ -1,0 +1,9 @@
+import styled from '../../theme'
+
+const H4 = styled.h4`
+  font-size: 25px;
+  font-weight: 500;
+  margin: 0;
+`
+
+export default H4

--- a/src/pages/HowWeWork.tsx
+++ b/src/pages/HowWeWork.tsx
@@ -6,6 +6,7 @@ import { HowWeWorkPageQuery } from '../../typings/iteamse'
 import Block from '../components/Blocks/Block'
 import ImageBleed from '../components/Blocks/ImageBleed'
 import ImageBlock from '../components/Blocks/ImageBlock'
+import OpenPositionsBlock from '../components/Blocks/OpenPositionsBlock'
 import GridColumn from '../components/Grid/GridColumn'
 import Header from '../components/Header/Header'
 import Team from '../components/Team/Team'
@@ -15,6 +16,11 @@ import howWeWorkImage from './img/illustrations-group-3.svg'
 
 export const HOW_WE_WORK_PAGE_QUERY = gql`
   query HowWeWorkPage {
+    openpositions {
+      location
+      id
+      title
+    }
     pageHowWeWork {
       headerImage
       headerText1
@@ -24,6 +30,8 @@ export const HOW_WE_WORK_PAGE_QUERY = gql`
       customersText
       customersTitle
       hiringTitle
+      openApplicationText
+      openApplicationHeader
       imageBleed
       methodText
       methodTitle
@@ -51,20 +59,14 @@ export class HowWeWork extends React.Component {
             return null
           }
 
-          const { pageHowWeWork } = data
+          const { openpositions, pageHowWeWork } = data
 
           return (
             <>
               <Helmet>
                 <title>Iteam | Hur vi jobbar</title>
-                <meta
-                  name="og:title"
-                  content="Iteam | Hur vi jobbar"
-                />
-                <meta
-                  name="twitter:title"
-                  content="Iteam | Hur vi jobbar"
-                />
+                <meta name="og:title" content="Iteam | Hur vi jobbar" />
+                <meta name="twitter:title" content="Iteam | Hur vi jobbar" />
                 {pageHowWeWork.headerImage && (
                   <meta
                     name="og:image"
@@ -87,7 +89,15 @@ export class HowWeWork extends React.Component {
                 <Block title={pageHowWeWork.methodTitle}>
                   {pageHowWeWork.methodText}
                 </Block>
-                <ImageBleed image={pageHowWeWork.imageBleed} />
+              </GridColumn>
+              <OpenPositionsBlock
+                openApplicationText={pageHowWeWork.openApplicationText}
+                openApplicationHeader={pageHowWeWork.openApplicationHeader}
+                openpositions={openpositions}
+                title={pageHowWeWork.hiringTitle}
+              />
+              <ImageBleed image={pageHowWeWork.imageBleed} />
+              <GridColumn>
                 <Block title={pageHowWeWork.sharingTitle}>
                   {pageHowWeWork.sharingText}
                 </Block>

--- a/src/pages/__fixtures__/pageHowWeWork.ts
+++ b/src/pages/__fixtures__/pageHowWeWork.ts
@@ -15,6 +15,8 @@ export const pageHowWeWork = {
   methodText:
     'Vi söker alltid efter den bästa processen. Den bästa metoden. Vi vågar ta risker, byta spår, byta teknik, experimentera och ifrågasätta både oss själva och våra kunder. Det är liksom det vi gör. Hela tiden.',
   methodTitle: 'Ständigt sökande',
+  openApplicationHeader: 'Inget som passar?',
+  openApplicationText: '[Spontanansök](mailto:joinus@iteam.se)',
   sharingText:
     'På våra kodluncher lär vi av varandra. Vi mentorerar och vi labbar ihop. Vi anordnar Lounge Hack, bidrar till open source, till forumet kodapor tillsammans med 12000 andra utvecklare och deltar på konferenser. Vår kunskap är din kunskap.',
   sharingTitle: 'Delar allt',

--- a/src/pages/__tests__/HowWeWork.spec.tsx
+++ b/src/pages/__tests__/HowWeWork.spec.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { render, wait } from 'react-testing-library'
 import MockedQuery from '../../utils/test-utils/MockedQuery'
+import { openpositions } from '../__fixtures__/openpositions'
 import { pageHowWeWork } from '../__fixtures__/pageHowWeWork'
 import { TeamQueryMock } from '../__fixtures__/teamMock'
 import HowWeWork, { HOW_WE_WORK_PAGE_QUERY } from '../HowWeWork'
@@ -12,6 +13,7 @@ const mocks = [
     },
     result: {
       data: {
+        openpositions,
         pageHowWeWork,
       },
     },

--- a/src/pages/__tests__/__snapshots__/About.spec.tsx.snap
+++ b/src/pages/__tests__/__snapshots__/About.spec.tsx.snap
@@ -4,85 +4,85 @@ exports[`components/About renders About 1`] = `
 <div>
   <div>
     <div
-      class="sc-lhVmIH gEEciN"
+      class="sc-gzOgki cRWgaF"
     >
       <div
-        class="sc-bYSBpT bdgTKs"
+        class="sc-iyvyFf fXFZjN"
       >
         <div
-          class="sc-kafWEX doqriu"
+          class="sc-elJkPf fqzjUn"
         >
           <a
-            class="sc-feJyhm bzbyYc"
+            class="sc-jtRfpW cXQLFZ"
           >
             <img
-              class="sc-iELTvK kXWcVM"
+              class="sc-kTUwUJ fgTIcp"
               data-testid="logo"
               path="test-file-stub"
             />
           </a>
           <div
-            class="sc-cmTdod gUTeYg"
+            class="sc-dqBHgY fDUITd"
           >
             <a
-              class="sc-btzYZH kmRwNW"
+              class="sc-dfVpRl uQOzH"
               aria-current="false"
             >
               Case
             </a>
             <a
-              class="sc-btzYZH kmRwNW"
+              class="sc-dfVpRl uQOzH"
               aria-current="false"
             >
               AI
             </a>
             <a
-              class="sc-btzYZH kmRwNW"
+              class="sc-dfVpRl uQOzH"
               aria-current="false"
             >
               Metod
             </a>
             <a
-              class="sc-btzYZH kmRwNW"
+              class="sc-dfVpRl uQOzH"
               aria-current="false"
             >
               Medarbetare
             </a>
             <a
-              class="sc-btzYZH kmRwNW"
+              class="sc-dfVpRl uQOzH"
               aria-current="false"
             >
               Karriär
             </a>
             <a
-              class="sc-btzYZH kmRwNW"
+              class="sc-dfVpRl uQOzH"
               aria-current="false"
             >
               Om
             </a>
             <a
-              class="sc-btzYZH kmRwNW"
+              class="sc-dfVpRl uQOzH"
               aria-current="false"
             >
               Drift & Support
             </a>
             <div
-              class="sc-jwKygS fTIVRr"
+              class="sc-gxMtzJ dqeSKx"
             />
           </div>
         </div>
         <div
-          class="sc-elJkPf kqIJd"
+          class="sc-hwwEjo fiJSKN"
         >
           <h1
-            class="sc-jtRfpW egqOis"
+            class="sc-kPVwWT eVGDkO"
           >
             <span>
               Vi skapades ur en vilja att skapa värde,
             </span>
           </h1>
           <h1
-            class="sc-jtRfpW egqOis"
+            class="sc-kPVwWT eVGDkO"
           >
             <span>
               ha kul och göra något bra

--- a/src/pages/__tests__/__snapshots__/Ai.spec.tsx.snap
+++ b/src/pages/__tests__/__snapshots__/Ai.spec.tsx.snap
@@ -4,78 +4,78 @@ exports[`components/Ai renders Ai 1`] = `
 <div>
   <div>
     <div
-      class="sc-lhVmIH fTQKsL"
+      class="sc-gzOgki lnNVuX"
     >
       <div
-        class="sc-bYSBpT bdgTKs"
+        class="sc-iyvyFf fXFZjN"
       >
         <div
-          class="sc-kafWEX doqriu"
+          class="sc-elJkPf fqzjUn"
         >
           <a
-            class="sc-feJyhm bzbyYc"
+            class="sc-jtRfpW cXQLFZ"
           >
             <img
-              class="sc-iELTvK kXWcVM"
+              class="sc-kTUwUJ fgTIcp"
               data-testid="logo"
               path="test-file-stub"
             />
           </a>
           <div
-            class="sc-cmTdod gUTeYg"
+            class="sc-dqBHgY fDUITd"
           >
             <a
-              class="sc-btzYZH kmRwNW"
+              class="sc-dfVpRl uQOzH"
               aria-current="false"
             >
               Case
             </a>
             <a
-              class="sc-btzYZH kmRwNW"
+              class="sc-dfVpRl uQOzH"
               aria-current="false"
             >
               AI
             </a>
             <a
-              class="sc-btzYZH kmRwNW"
+              class="sc-dfVpRl uQOzH"
               aria-current="false"
             >
               Metod
             </a>
             <a
-              class="sc-btzYZH kmRwNW"
+              class="sc-dfVpRl uQOzH"
               aria-current="false"
             >
               Medarbetare
             </a>
             <a
-              class="sc-btzYZH kmRwNW"
+              class="sc-dfVpRl uQOzH"
               aria-current="false"
             >
               Karriär
             </a>
             <a
-              class="sc-btzYZH kmRwNW"
+              class="sc-dfVpRl uQOzH"
               aria-current="false"
             >
               Om
             </a>
             <a
-              class="sc-btzYZH kmRwNW"
+              class="sc-dfVpRl uQOzH"
               aria-current="false"
             >
               Drift & Support
             </a>
             <div
-              class="sc-jwKygS fTIVRr"
+              class="sc-gxMtzJ dqeSKx"
             />
           </div>
         </div>
         <div
-          class="sc-elJkPf kqIJd"
+          class="sc-hwwEjo fiJSKN"
         >
           <h1
-            class="sc-jtRfpW cAjlcN"
+            class="sc-kPVwWT bqQroT"
           >
             <span>
               Våra erbjudanden inom AI

--- a/src/pages/__tests__/__snapshots__/Case.spec.tsx.snap
+++ b/src/pages/__tests__/__snapshots__/Case.spec.tsx.snap
@@ -7,64 +7,64 @@ exports[`components/Case renders Case 1`] = `
     data-test="header-case"
   >
     <div
-      class="sc-kafWEX doqriu"
+      class="sc-elJkPf fqzjUn"
     >
       <a
-        class="sc-feJyhm bzbyYc"
+        class="sc-jtRfpW cXQLFZ"
       >
         <img
-          class="sc-iELTvK kXWcVM"
+          class="sc-kTUwUJ fgTIcp"
           data-testid="logo"
           path="test-file-stub"
         />
       </a>
       <div
-        class="sc-cmTdod gUTeYg"
+        class="sc-dqBHgY fDUITd"
       >
         <a
-          class="sc-btzYZH kmRwNW active-nav"
+          class="sc-dfVpRl uQOzH active-nav"
           aria-current="true"
         >
           Case
         </a>
         <a
-          class="sc-btzYZH kmRwNW"
+          class="sc-dfVpRl uQOzH"
           aria-current="false"
         >
           AI
         </a>
         <a
-          class="sc-btzYZH kmRwNW"
+          class="sc-dfVpRl uQOzH"
           aria-current="false"
         >
           Metod
         </a>
         <a
-          class="sc-btzYZH kmRwNW"
+          class="sc-dfVpRl uQOzH"
           aria-current="false"
         >
           Medarbetare
         </a>
         <a
-          class="sc-btzYZH kmRwNW"
+          class="sc-dfVpRl uQOzH"
           aria-current="false"
         >
           Karriär
         </a>
         <a
-          class="sc-btzYZH kmRwNW"
+          class="sc-dfVpRl uQOzH"
           aria-current="false"
         >
           Om
         </a>
         <a
-          class="sc-btzYZH kmRwNW"
+          class="sc-dfVpRl uQOzH"
           aria-current="false"
         >
           Drift & Support
         </a>
         <div
-          class="sc-jwKygS fTIVRr"
+          class="sc-gxMtzJ dqeSKx"
         />
       </div>
     </div>

--- a/src/pages/__tests__/__snapshots__/Cases.spec.tsx.snap
+++ b/src/pages/__tests__/__snapshots__/Cases.spec.tsx.snap
@@ -4,85 +4,85 @@ exports[`components/Cases renders Cases 1`] = `
 <div>
   <div>
     <div
-      class="sc-lhVmIH jjPecX"
+      class="sc-gzOgki xJgjf"
     >
       <div
-        class="sc-bYSBpT bdgTKs"
+        class="sc-iyvyFf fXFZjN"
       >
         <div
-          class="sc-kafWEX doqriu"
+          class="sc-elJkPf fqzjUn"
         >
           <a
-            class="sc-feJyhm bzbyYc"
+            class="sc-jtRfpW cXQLFZ"
           >
             <img
-              class="sc-iELTvK kXWcVM"
+              class="sc-kTUwUJ fgTIcp"
               data-testid="logo"
               path="test-file-stub"
             />
           </a>
           <div
-            class="sc-cmTdod gUTeYg"
+            class="sc-dqBHgY fDUITd"
           >
             <a
-              class="sc-btzYZH kmRwNW"
+              class="sc-dfVpRl uQOzH"
               aria-current="false"
             >
               Case
             </a>
             <a
-              class="sc-btzYZH kmRwNW"
+              class="sc-dfVpRl uQOzH"
               aria-current="false"
             >
               AI
             </a>
             <a
-              class="sc-btzYZH kmRwNW"
+              class="sc-dfVpRl uQOzH"
               aria-current="false"
             >
               Metod
             </a>
             <a
-              class="sc-btzYZH kmRwNW"
+              class="sc-dfVpRl uQOzH"
               aria-current="false"
             >
               Medarbetare
             </a>
             <a
-              class="sc-btzYZH kmRwNW"
+              class="sc-dfVpRl uQOzH"
               aria-current="false"
             >
               Karriär
             </a>
             <a
-              class="sc-btzYZH kmRwNW"
+              class="sc-dfVpRl uQOzH"
               aria-current="false"
             >
               Om
             </a>
             <a
-              class="sc-btzYZH kmRwNW"
+              class="sc-dfVpRl uQOzH"
               aria-current="false"
             >
               Drift & Support
             </a>
             <div
-              class="sc-jwKygS fTIVRr"
+              class="sc-gxMtzJ dqeSKx"
             />
           </div>
         </div>
         <div
-          class="sc-elJkPf kqIJd"
+          class="sc-hwwEjo fiJSKN"
         >
           <h1
-            class="sc-jtRfpW egqOis"
+            class="sc-kPVwWT eVGDkO"
           >
             <span>
               Några exempel på
             </span>
           </h1>
           <h1
-            class="sc-jtRfpW egqOis"
+            class="sc-kPVwWT eVGDkO"
           >
             <span>
               sådant vi gjort

--- a/src/pages/__tests__/__snapshots__/Home.spec.tsx.snap
+++ b/src/pages/__tests__/__snapshots__/Home.spec.tsx.snap
@@ -4,85 +4,85 @@ exports[`components/Home renders Home 1`] = `
 <div>
   <div>
     <div
-      class="sc-lhVmIH kTWvui"
+      class="sc-gzOgki fpllMB"
     >
       <div
-        class="sc-bYSBpT bdgTKs"
+        class="sc-iyvyFf fXFZjN"
       >
         <div
-          class="sc-kafWEX doqriu"
+          class="sc-elJkPf fqzjUn"
         >
           <a
-            class="sc-feJyhm bzbyYc"
+            class="sc-jtRfpW cXQLFZ"
           >
             <img
-              class="sc-iELTvK kXWcVM"
+              class="sc-kTUwUJ fgTIcp"
               data-testid="logo"
               path="test-file-stub"
             />
           </a>
           <div
-            class="sc-cmTdod gUTeYg"
+            class="sc-dqBHgY fDUITd"
           >
             <a
-              class="sc-btzYZH kmRwNW"
+              class="sc-dfVpRl uQOzH"
               aria-current="false"
             >
               Case
             </a>
             <a
-              class="sc-btzYZH kmRwNW"
+              class="sc-dfVpRl uQOzH"
               aria-current="false"
             >
               AI
             </a>
             <a
-              class="sc-btzYZH kmRwNW"
+              class="sc-dfVpRl uQOzH"
               aria-current="false"
             >
               Metod
             </a>
             <a
-              class="sc-btzYZH kmRwNW"
+              class="sc-dfVpRl uQOzH"
               aria-current="false"
             >
               Medarbetare
             </a>
             <a
-              class="sc-btzYZH kmRwNW"
+              class="sc-dfVpRl uQOzH"
               aria-current="false"
             >
               Karriär
             </a>
             <a
-              class="sc-btzYZH kmRwNW"
+              class="sc-dfVpRl uQOzH"
               aria-current="false"
             >
               Om
             </a>
             <a
-              class="sc-btzYZH kmRwNW"
+              class="sc-dfVpRl uQOzH"
               aria-current="false"
             >
               Drift & Support
             </a>
             <div
-              class="sc-jwKygS fTIVRr"
+              class="sc-gxMtzJ dqeSKx"
             />
           </div>
         </div>
         <div
-          class="sc-elJkPf kqIJd"
+          class="sc-hwwEjo fiJSKN"
         >
           <h1
-            class="sc-jtRfpW hCjAru"
+            class="sc-kPVwWT AQYAf"
           >
             <span>
               Vi digitaliserar företag och organisationer
             </span>
           </h1>
           <h1
-            class="sc-jtRfpW hCjAru"
+            class="sc-kPVwWT AQYAf"
           >
             <span>
               genom strategi, kod och kultur

--- a/src/pages/__tests__/__snapshots__/HowWeWork.spec.tsx.snap
+++ b/src/pages/__tests__/__snapshots__/HowWeWork.spec.tsx.snap
@@ -4,78 +4,78 @@ exports[`components/HowWeWork renders HowWeWork 1`] = `
 <div>
   <div>
     <div
-      class="sc-lhVmIH gEEciN"
+      class="sc-gzOgki cRWgaF"
     >
       <div
-        class="sc-bYSBpT bdgTKs"
+        class="sc-iyvyFf fXFZjN"
       >
         <div
-          class="sc-kafWEX doqriu"
+          class="sc-elJkPf fqzjUn"
         >
           <a
-            class="sc-feJyhm bzbyYc"
+            class="sc-jtRfpW cXQLFZ"
           >
             <img
-              class="sc-iELTvK kXWcVM"
+              class="sc-kTUwUJ fgTIcp"
               data-testid="logo"
               path="test-file-stub"
             />
           </a>
           <div
-            class="sc-cmTdod gUTeYg"
+            class="sc-dqBHgY fDUITd"
           >
             <a
-              class="sc-btzYZH kmRwNW"
+              class="sc-dfVpRl uQOzH"
               aria-current="false"
             >
               Case
             </a>
             <a
-              class="sc-btzYZH kmRwNW"
+              class="sc-dfVpRl uQOzH"
               aria-current="false"
             >
               AI
             </a>
             <a
-              class="sc-btzYZH kmRwNW"
+              class="sc-dfVpRl uQOzH"
               aria-current="false"
             >
               Metod
             </a>
             <a
-              class="sc-btzYZH kmRwNW"
+              class="sc-dfVpRl uQOzH"
               aria-current="false"
             >
               Medarbetare
             </a>
             <a
-              class="sc-btzYZH kmRwNW"
+              class="sc-dfVpRl uQOzH"
               aria-current="false"
             >
               Karriär
             </a>
             <a
-              class="sc-btzYZH kmRwNW"
+              class="sc-dfVpRl uQOzH"
               aria-current="false"
             >
               Om
             </a>
             <a
-              class="sc-btzYZH kmRwNW"
+              class="sc-dfVpRl uQOzH"
               aria-current="false"
             >
               Drift & Support
             </a>
             <div
-              class="sc-jwKygS fTIVRr"
+              class="sc-gxMtzJ dqeSKx"
             />
           </div>
         </div>
         <div
-          class="sc-elJkPf kqIJd"
+          class="sc-hwwEjo fiJSKN"
         >
           <h1
-            class="sc-jtRfpW gYccdl"
+            class="sc-kPVwWT kWnKUp"
           >
             <span>
               Så här jobbar vi 
@@ -168,10 +168,83 @@ exports[`components/HowWeWork renders HowWeWork 1`] = `
         </div>
       </div>
     </div>
-    <img
-      class="sc-gqjmRU kaGJTv"
-      src="//images.ctfassets.net/rj4r6yfcesw5/62hgzE8G3ueMa2YSEuG4og/db2b643db6041f9d26936bc2d6006607/bleed_howwework.jpg"
-    />
+  </div>
+  <div
+    class="react-reveal"
+    style="opacity: 1;"
+  >
+    <div
+      class="sc-jbKcbu DURVc"
+    >
+      <div
+        class="sc-bdVaJa fGzlqx"
+        data-test="block-"
+      >
+        <div
+          class="sc-dNLxif hzWfTN"
+        >
+          <div
+            class="sc-jqCOkK heXNii"
+          >
+            <h3
+              class="sc-bwzfXH kgEpTV"
+            >
+              Just nu söker vi
+            </h3>
+            <ul
+              class="sc-uJMKN gGebAW"
+            >
+              <li
+                class="sc-gGBfsJ kgVDeQ"
+              >
+                <a
+                  class="sc-caSCKo culsyQ"
+                >
+                  Junior UX Designer
+                </a>
+                (
+                Stockholm
+                )
+              </li>
+            </ul>
+          </div>
+          <div
+            class="sc-jqCOkK heXNii"
+          >
+            <h4
+              class="sc-hqyNC fgUISZ"
+            >
+              Inget som passar?
+            </h4>
+            <div
+              class="sc-bbmXgH kIolfQ"
+            >
+              <div
+                class="sc-htpNat iEyarI"
+              >
+                <div>
+                  <p>
+                    <a
+                      href="mailto:joinus@iteam.se"
+                    >
+                      Spontanansök
+                    </a>
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <img
+    class="sc-gqjmRU kaGJTv"
+    src="//images.ctfassets.net/rj4r6yfcesw5/62hgzE8G3ueMa2YSEuG4og/db2b643db6041f9d26936bc2d6006607/bleed_howwework.jpg"
+  />
+  <div
+    class="sc-iwsKbI fwFOwW"
+  >
     <div
       class="react-reveal"
       style="opacity: 1;"

--- a/src/pages/__tests__/__snapshots__/OpenPosition.spec.tsx.snap
+++ b/src/pages/__tests__/__snapshots__/OpenPosition.spec.tsx.snap
@@ -4,85 +4,85 @@ exports[`components/OpenPosition renders OpenPosition 1`] = `
 <div>
   <div>
     <div
-      class="sc-lhVmIH cMbxDN"
+      class="sc-gzOgki dtyxCS"
     >
       <div
-        class="sc-bYSBpT bdgTKs"
+        class="sc-iyvyFf fXFZjN"
       >
         <div
-          class="sc-kafWEX doqriu"
+          class="sc-elJkPf fqzjUn"
         >
           <a
-            class="sc-feJyhm bzbyYc"
+            class="sc-jtRfpW cXQLFZ"
           >
             <img
-              class="sc-iELTvK kXWcVM"
+              class="sc-kTUwUJ fgTIcp"
               data-testid="logo"
               path="test-file-stub"
             />
           </a>
           <div
-            class="sc-cmTdod gUTeYg"
+            class="sc-dqBHgY fDUITd"
           >
             <a
-              class="sc-btzYZH kmRwNW"
+              class="sc-dfVpRl uQOzH"
               aria-current="false"
             >
               Case
             </a>
             <a
-              class="sc-btzYZH kmRwNW"
+              class="sc-dfVpRl uQOzH"
               aria-current="false"
             >
               AI
             </a>
             <a
-              class="sc-btzYZH kmRwNW"
+              class="sc-dfVpRl uQOzH"
               aria-current="false"
             >
               Metod
             </a>
             <a
-              class="sc-btzYZH kmRwNW"
+              class="sc-dfVpRl uQOzH"
               aria-current="false"
             >
               Medarbetare
             </a>
             <a
-              class="sc-btzYZH kmRwNW active-nav"
+              class="sc-dfVpRl uQOzH active-nav"
               aria-current="true"
             >
               Karriär
             </a>
             <a
-              class="sc-btzYZH kmRwNW"
+              class="sc-dfVpRl uQOzH"
               aria-current="false"
             >
               Om
             </a>
             <a
-              class="sc-btzYZH kmRwNW"
+              class="sc-dfVpRl uQOzH"
               aria-current="false"
             >
               Drift & Support
             </a>
             <div
-              class="sc-jwKygS fTIVRr"
+              class="sc-gxMtzJ dqeSKx"
             />
           </div>
         </div>
         <div
-          class="sc-elJkPf kqIJd"
+          class="sc-hwwEjo fiJSKN"
         >
           <h1
-            class="sc-jtRfpW gYccdl"
+            class="sc-kPVwWT kWnKUp"
           >
             <span>
               UX Designer
             </span>
           </h1>
           <h1
-            class="sc-jtRfpW gYccdl"
+            class="sc-kPVwWT kWnKUp"
           >
             <span>
               Stockholm

--- a/src/pages/__tests__/__snapshots__/Ops.spec.tsx.snap
+++ b/src/pages/__tests__/__snapshots__/Ops.spec.tsx.snap
@@ -4,85 +4,85 @@ exports[`components/Ops renders Ops 1`] = `
 <div>
   <div>
     <div
-      class="sc-lhVmIH foDRHj"
+      class="sc-gzOgki jellwR"
     >
       <div
-        class="sc-bYSBpT bdgTKs"
+        class="sc-iyvyFf fXFZjN"
       >
         <div
-          class="sc-kafWEX doqriu"
+          class="sc-elJkPf fqzjUn"
         >
           <a
-            class="sc-feJyhm bzbyYc"
+            class="sc-jtRfpW cXQLFZ"
           >
             <img
-              class="sc-iELTvK kXWcVM"
+              class="sc-kTUwUJ fgTIcp"
               data-testid="logo"
               path="test-file-stub"
             />
           </a>
           <div
-            class="sc-cmTdod gUTeYg"
+            class="sc-dqBHgY fDUITd"
           >
             <a
-              class="sc-btzYZH kmRwNW"
+              class="sc-dfVpRl uQOzH"
               aria-current="false"
             >
               Case
             </a>
             <a
-              class="sc-btzYZH kmRwNW"
+              class="sc-dfVpRl uQOzH"
               aria-current="false"
             >
               AI
             </a>
             <a
-              class="sc-btzYZH kmRwNW"
+              class="sc-dfVpRl uQOzH"
               aria-current="false"
             >
               Metod
             </a>
             <a
-              class="sc-btzYZH kmRwNW"
+              class="sc-dfVpRl uQOzH"
               aria-current="false"
             >
               Medarbetare
             </a>
             <a
-              class="sc-btzYZH kmRwNW"
+              class="sc-dfVpRl uQOzH"
               aria-current="false"
             >
               Karriär
             </a>
             <a
-              class="sc-btzYZH kmRwNW"
+              class="sc-dfVpRl uQOzH"
               aria-current="false"
             >
               Om
             </a>
             <a
-              class="sc-btzYZH kmRwNW"
+              class="sc-dfVpRl uQOzH"
               aria-current="false"
             >
               Drift & Support
             </a>
             <div
-              class="sc-jwKygS fTIVRr"
+              class="sc-gxMtzJ dqeSKx"
             />
           </div>
         </div>
         <div
-          class="sc-elJkPf kqIJd"
+          class="sc-hwwEjo fiJSKN"
         >
           <h1
-            class="sc-jtRfpW dJthJP"
+            class="sc-kPVwWT isSAXL"
           >
             <span>
               Skräddarsydd drift och support
             </span>
           </h1>
           <h1
-            class="sc-jtRfpW dJthJP"
+            class="sc-kPVwWT isSAXL"
           >
             <span>
               sedan 1995

--- a/src/pages/__tests__/__snapshots__/Team.spec.tsx.snap
+++ b/src/pages/__tests__/__snapshots__/Team.spec.tsx.snap
@@ -4,78 +4,78 @@ exports[`components/Team renders Team 1`] = `
 <div>
   <div>
     <div
-      class="sc-dqBHgY cGUgLT"
+      class="sc-kfGgVZ cJhZbQ"
     >
       <div
-        class="sc-gxMtzJ eXQJvD"
+        class="sc-esjQYD gyxPqE"
       >
         <div
-          class="sc-btzYZH cZSewS"
+          class="sc-gxMtzJ bEcMgf"
         >
           <a
-            class="sc-lhVmIH ikqhWa"
+            class="sc-dfVpRl ftufec"
           >
             <img
-              class="sc-bYSBpT dCPoBO"
+              class="sc-gzOgki dcLasU"
               data-testid="logo"
               path="test-file-stub"
             />
           </a>
           <div
-            class="sc-elJkPf kVhaog"
+            class="sc-iyvyFf hDzHAZ"
           >
             <a
-              class="sc-kTUwUJ fEMxFB"
+              class="sc-kPVwWT hwJsDC"
               aria-current="false"
             >
               Case
             </a>
             <a
-              class="sc-kTUwUJ fEMxFB"
+              class="sc-kPVwWT hwJsDC"
               aria-current="false"
             >
               AI
             </a>
             <a
-              class="sc-kTUwUJ fEMxFB"
+              class="sc-kPVwWT hwJsDC"
               aria-current="false"
             >
               Metod
             </a>
             <a
-              class="sc-kTUwUJ fEMxFB"
+              class="sc-kPVwWT hwJsDC"
               aria-current="false"
             >
               Medarbetare
             </a>
             <a
-              class="sc-kTUwUJ fEMxFB"
+              class="sc-kPVwWT hwJsDC"
               aria-current="false"
             >
               Karriär
             </a>
             <a
-              class="sc-kTUwUJ fEMxFB"
+              class="sc-kPVwWT hwJsDC"
               aria-current="false"
             >
               Om
             </a>
             <a
-              class="sc-kTUwUJ fEMxFB"
+              class="sc-kPVwWT hwJsDC"
               aria-current="false"
             >
               Drift & Support
             </a>
             <div
-              class="sc-jtRfpW hwCVJp"
+              class="sc-hwwEjo ckZktb"
             />
           </div>
         </div>
         <div
-          class="sc-dfVpRl hlzXex"
+          class="sc-kIPQKe eytleb"
         >
           <h1
-            class="sc-gzOgki gWEEDl"
+            class="sc-eXEjpC fZznAL"
           >
             <span>
               Det är vi som är Iteam
@@ -126,7 +126,7 @@ exports[`components/Team renders Team 1`] = `
             class="sc-kpOJdX eNhRjC"
           >
             <div
-              class="sc-kPVwWT bAZnwm"
+              class="sc-iQKALj cwUche"
             >
               <div>
                 <img
@@ -138,17 +138,17 @@ exports[`components/Team renders Team 1`] = `
             </div>
           </a>
           <div
-            class="sc-iyvyFf hIGtnG"
+            class="sc-ibxdXY gnGofC"
           >
             Cookie M
           </div>
           <div
-            class="sc-hwwEjo fMbrdn"
+            class="sc-RefOD jVyGH"
           >
             Cookie master
           </div>
           <div
-            class="sc-kfGgVZ dejRES"
+            class="sc-bwCtUz hkbqF"
           >
             <a
               class="sc-chPdSV hAACpH"
@@ -171,7 +171,7 @@ exports[`components/Team renders Team 1`] = `
             class="sc-kpOJdX eNhRjC"
           >
             <div
-              class="sc-kPVwWT bAZnwm"
+              class="sc-iQKALj cwUche"
             >
               <div>
                 <img
@@ -183,17 +183,17 @@ exports[`components/Team renders Team 1`] = `
             </div>
           </a>
           <div
-            class="sc-iyvyFf hIGtnG"
+            class="sc-ibxdXY gnGofC"
           >
             Count van Count
           </div>
           <div
-            class="sc-hwwEjo fMbrdn"
+            class="sc-RefOD jVyGH"
           >
             1 ahahah
           </div>
           <div
-            class="sc-kfGgVZ dejRES"
+            class="sc-bwCtUz hkbqF"
           >
             <a
               class="sc-chPdSV hAACpH"
@@ -219,78 +219,78 @@ exports[`components/Team should handle changing location using keyboard 1`] = `
 <div>
   <div>
     <div
-      class="sc-dqBHgY cGUgLT"
+      class="sc-kfGgVZ cJhZbQ"
     >
       <div
-        class="sc-gxMtzJ eXQJvD"
+        class="sc-esjQYD gyxPqE"
       >
         <div
-          class="sc-btzYZH cZSewS"
+          class="sc-gxMtzJ bEcMgf"
         >
           <a
-            class="sc-lhVmIH ikqhWa"
+            class="sc-dfVpRl ftufec"
           >
             <img
-              class="sc-bYSBpT dCPoBO"
+              class="sc-gzOgki dcLasU"
               data-testid="logo"
               path="test-file-stub"
             />
           </a>
           <div
-            class="sc-elJkPf kVhaog"
+            class="sc-iyvyFf hDzHAZ"
           >
             <a
-              class="sc-kTUwUJ fEMxFB"
+              class="sc-kPVwWT hwJsDC"
               aria-current="false"
             >
               Case
             </a>
             <a
-              class="sc-kTUwUJ fEMxFB"
+              class="sc-kPVwWT hwJsDC"
               aria-current="false"
             >
               AI
             </a>
             <a
-              class="sc-kTUwUJ fEMxFB"
+              class="sc-kPVwWT hwJsDC"
               aria-current="false"
             >
               Metod
             </a>
             <a
-              class="sc-kTUwUJ fEMxFB"
+              class="sc-kPVwWT hwJsDC"
               aria-current="false"
             >
               Medarbetare
             </a>
             <a
-              class="sc-kTUwUJ fEMxFB"
+              class="sc-kPVwWT hwJsDC"
               aria-current="false"
             >
               Karriär
             </a>
             <a
-              class="sc-kTUwUJ fEMxFB"
+              class="sc-kPVwWT hwJsDC"
               aria-current="false"
             >
               Om
             </a>
             <a
-              class="sc-kTUwUJ fEMxFB"
+              class="sc-kPVwWT hwJsDC"
               aria-current="false"
             >
               Drift & Support
             </a>
             <div
-              class="sc-jtRfpW hwCVJp"
+              class="sc-hwwEjo ckZktb"
             />
           </div>
         </div>
         <div
-          class="sc-dfVpRl hlzXex"
+          class="sc-kIPQKe eytleb"
         >
           <h1
-            class="sc-gzOgki gWEEDl"
+            class="sc-eXEjpC fZznAL"
           >
             <span>
               Det är vi som är Iteam
@@ -341,7 +341,7 @@ exports[`components/Team should handle changing location using keyboard 1`] = `
             class="sc-kpOJdX eNhRjC"
           >
             <div
-              class="sc-kPVwWT bAZnwm"
+              class="sc-iQKALj cwUche"
             >
               <div>
                 <img
@@ -353,17 +353,17 @@ exports[`components/Team should handle changing location using keyboard 1`] = `
             </div>
           </a>
           <div
-            class="sc-iyvyFf hIGtnG"
+            class="sc-ibxdXY gnGofC"
           >
             Count van Count
           </div>
           <div
-            class="sc-hwwEjo fMbrdn"
+            class="sc-RefOD jVyGH"
           >
             1 ahahah
           </div>
           <div
-            class="sc-kfGgVZ dejRES"
+            class="sc-bwCtUz hkbqF"
           >
             <a
               class="sc-chPdSV hAACpH"
@@ -389,78 +389,78 @@ exports[`components/Team should handle changing location using mouse 1`] = `
 <div>
   <div>
     <div
-      class="sc-dqBHgY cGUgLT"
+      class="sc-kfGgVZ cJhZbQ"
     >
       <div
-        class="sc-gxMtzJ eXQJvD"
+        class="sc-esjQYD gyxPqE"
       >
         <div
-          class="sc-btzYZH cZSewS"
+          class="sc-gxMtzJ bEcMgf"
         >
           <a
-            class="sc-lhVmIH ikqhWa"
+            class="sc-dfVpRl ftufec"
           >
             <img
-              class="sc-bYSBpT dCPoBO"
+              class="sc-gzOgki dcLasU"
               data-testid="logo"
               path="test-file-stub"
             />
           </a>
           <div
-            class="sc-elJkPf kVhaog"
+            class="sc-iyvyFf hDzHAZ"
           >
             <a
-              class="sc-kTUwUJ fEMxFB"
+              class="sc-kPVwWT hwJsDC"
               aria-current="false"
             >
               Case
             </a>
             <a
-              class="sc-kTUwUJ fEMxFB"
+              class="sc-kPVwWT hwJsDC"
               aria-current="false"
             >
               AI
             </a>
             <a
-              class="sc-kTUwUJ fEMxFB"
+              class="sc-kPVwWT hwJsDC"
               aria-current="false"
             >
               Metod
             </a>
             <a
-              class="sc-kTUwUJ fEMxFB"
+              class="sc-kPVwWT hwJsDC"
               aria-current="false"
             >
               Medarbetare
             </a>
             <a
-              class="sc-kTUwUJ fEMxFB"
+              class="sc-kPVwWT hwJsDC"
               aria-current="false"
             >
               Karriär
             </a>
             <a
-              class="sc-kTUwUJ fEMxFB"
+              class="sc-kPVwWT hwJsDC"
               aria-current="false"
             >
               Om
             </a>
             <a
-              class="sc-kTUwUJ fEMxFB"
+              class="sc-kPVwWT hwJsDC"
               aria-current="false"
             >
               Drift & Support
             </a>
             <div
-              class="sc-jtRfpW hwCVJp"
+              class="sc-hwwEjo ckZktb"
             />
           </div>
         </div>
         <div
-          class="sc-dfVpRl hlzXex"
+          class="sc-kIPQKe eytleb"
         >
           <h1
-            class="sc-gzOgki gWEEDl"
+            class="sc-eXEjpC fZznAL"
           >
             <span>
               Det är vi som är Iteam
@@ -511,7 +511,7 @@ exports[`components/Team should handle changing location using mouse 1`] = `
             class="sc-kpOJdX eNhRjC"
           >
             <div
-              class="sc-kPVwWT bAZnwm"
+              class="sc-iQKALj cwUche"
             >
               <div>
                 <img
@@ -523,17 +523,17 @@ exports[`components/Team should handle changing location using mouse 1`] = `
             </div>
           </a>
           <div
-            class="sc-iyvyFf hIGtnG"
+            class="sc-ibxdXY gnGofC"
           >
             Cookie M
           </div>
           <div
-            class="sc-hwwEjo fMbrdn"
+            class="sc-RefOD jVyGH"
           >
             Cookie master
           </div>
           <div
-            class="sc-kfGgVZ dejRES"
+            class="sc-bwCtUz hkbqF"
           >
             <a
               class="sc-chPdSV hAACpH"
@@ -559,78 +559,78 @@ exports[`components/Team should not change using keyboard if not enter or space 
 <div>
   <div>
     <div
-      class="sc-dqBHgY cGUgLT"
+      class="sc-kfGgVZ cJhZbQ"
     >
       <div
-        class="sc-gxMtzJ eXQJvD"
+        class="sc-esjQYD gyxPqE"
       >
         <div
-          class="sc-btzYZH cZSewS"
+          class="sc-gxMtzJ bEcMgf"
         >
           <a
-            class="sc-lhVmIH ikqhWa"
+            class="sc-dfVpRl ftufec"
           >
             <img
-              class="sc-bYSBpT dCPoBO"
+              class="sc-gzOgki dcLasU"
               data-testid="logo"
               path="test-file-stub"
             />
           </a>
           <div
-            class="sc-elJkPf kVhaog"
+            class="sc-iyvyFf hDzHAZ"
           >
             <a
-              class="sc-kTUwUJ fEMxFB"
+              class="sc-kPVwWT hwJsDC"
               aria-current="false"
             >
               Case
             </a>
             <a
-              class="sc-kTUwUJ fEMxFB"
+              class="sc-kPVwWT hwJsDC"
               aria-current="false"
             >
               AI
             </a>
             <a
-              class="sc-kTUwUJ fEMxFB"
+              class="sc-kPVwWT hwJsDC"
               aria-current="false"
             >
               Metod
             </a>
             <a
-              class="sc-kTUwUJ fEMxFB"
+              class="sc-kPVwWT hwJsDC"
               aria-current="false"
             >
               Medarbetare
             </a>
             <a
-              class="sc-kTUwUJ fEMxFB"
+              class="sc-kPVwWT hwJsDC"
               aria-current="false"
             >
               Karriär
             </a>
             <a
-              class="sc-kTUwUJ fEMxFB"
+              class="sc-kPVwWT hwJsDC"
               aria-current="false"
             >
               Om
             </a>
             <a
-              class="sc-kTUwUJ fEMxFB"
+              class="sc-kPVwWT hwJsDC"
               aria-current="false"
             >
               Drift & Support
             </a>
             <div
-              class="sc-jtRfpW hwCVJp"
+              class="sc-hwwEjo ckZktb"
             />
           </div>
         </div>
         <div
-          class="sc-dfVpRl hlzXex"
+          class="sc-kIPQKe eytleb"
         >
           <h1
-            class="sc-gzOgki gWEEDl"
+            class="sc-eXEjpC fZznAL"
           >
             <span>
               Det är vi som är Iteam
@@ -681,7 +681,7 @@ exports[`components/Team should not change using keyboard if not enter or space 
             class="sc-kpOJdX eNhRjC"
           >
             <div
-              class="sc-kPVwWT bAZnwm"
+              class="sc-iQKALj cwUche"
             >
               <div>
                 <img
@@ -693,17 +693,17 @@ exports[`components/Team should not change using keyboard if not enter or space 
             </div>
           </a>
           <div
-            class="sc-iyvyFf hIGtnG"
+            class="sc-ibxdXY gnGofC"
           >
             Cookie M
           </div>
           <div
-            class="sc-hwwEjo fMbrdn"
+            class="sc-RefOD jVyGH"
           >
             Cookie master
           </div>
           <div
-            class="sc-kfGgVZ dejRES"
+            class="sc-bwCtUz hkbqF"
           >
             <a
               class="sc-chPdSV hAACpH"
@@ -726,7 +726,7 @@ exports[`components/Team should not change using keyboard if not enter or space 
             class="sc-kpOJdX eNhRjC"
           >
             <div
-              class="sc-kPVwWT bAZnwm"
+              class="sc-iQKALj cwUche"
             >
               <div>
                 <img
@@ -738,17 +738,17 @@ exports[`components/Team should not change using keyboard if not enter or space 
             </div>
           </a>
           <div
-            class="sc-iyvyFf hIGtnG"
+            class="sc-ibxdXY gnGofC"
           >
             Count van Count
           </div>
           <div
-            class="sc-hwwEjo fMbrdn"
+            class="sc-RefOD jVyGH"
           >
             1 ahahah
           </div>
           <div
-            class="sc-kfGgVZ dejRES"
+            class="sc-bwCtUz hkbqF"
           >
             <a
               class="sc-chPdSV hAACpH"

--- a/src/pages/__tests__/__snapshots__/TeamMember.spec.tsx.snap
+++ b/src/pages/__tests__/__snapshots__/TeamMember.spec.tsx.snap
@@ -3,89 +3,89 @@
 exports[`components/Team renders TeamMember 1`] = `
 <div>
   <div
-    class="sc-dqBHgY fFpsHk"
+    class="sc-kfGgVZ kgatDS"
   >
     <div>
       <div
-        class="sc-lhVmIH hOiqEn"
+        class="sc-gzOgki eiRsrn"
       >
         <div
-          class="sc-bYSBpT bdgTKs"
+          class="sc-iyvyFf fXFZjN"
         >
           <div
-            class="sc-kafWEX doqriu"
+            class="sc-elJkPf fqzjUn"
           >
             <a
-              class="sc-feJyhm bzbyYc"
+              class="sc-jtRfpW cXQLFZ"
             >
               <img
-                class="sc-iELTvK kXWcVM"
+                class="sc-kTUwUJ fgTIcp"
                 data-testid="logo"
                 path="test-file-stub"
               />
             </a>
             <div
-              class="sc-cmTdod gUTeYg"
+              class="sc-dqBHgY fDUITd"
             >
               <a
-                class="sc-btzYZH kmRwNW"
+                class="sc-dfVpRl uQOzH"
                 aria-current="false"
               >
                 Case
               </a>
               <a
-                class="sc-btzYZH kmRwNW"
+                class="sc-dfVpRl uQOzH"
                 aria-current="false"
               >
                 AI
               </a>
               <a
-                class="sc-btzYZH kmRwNW"
+                class="sc-dfVpRl uQOzH"
                 aria-current="false"
               >
                 Metod
               </a>
               <a
-                class="sc-btzYZH kmRwNW active-nav"
+                class="sc-dfVpRl uQOzH active-nav"
                 aria-current="true"
               >
                 Medarbetare
               </a>
               <a
-                class="sc-btzYZH kmRwNW"
+                class="sc-dfVpRl uQOzH"
                 aria-current="false"
               >
                 Karriär
               </a>
               <a
-                class="sc-btzYZH kmRwNW"
+                class="sc-dfVpRl uQOzH"
                 aria-current="false"
               >
                 Om
               </a>
               <a
-                class="sc-btzYZH kmRwNW"
+                class="sc-dfVpRl uQOzH"
                 aria-current="false"
               >
                 Drift & Support
               </a>
               <div
-                class="sc-jwKygS fTIVRr"
+                class="sc-gxMtzJ dqeSKx"
               />
             </div>
           </div>
           <div
-            class="sc-elJkPf kqIJd"
+            class="sc-hwwEjo fiJSKN"
           >
             <h1
-              class="sc-jtRfpW gYccdl"
+              class="sc-kPVwWT kWnKUp"
             >
               <span>
                 Rickard Laurin
               </span>
             </h1>
             <h1
-              class="sc-jtRfpW gYccdl"
+              class="sc-kPVwWT kWnKUp"
             >
               <span>
                 Webbutvecklare
@@ -135,11 +135,11 @@ exports[`components/Team renders TeamMember 1`] = `
               class="sc-bZQynM hmvJjY"
             >
               <ul
-                class="sc-kTUwUJ bEvEzc"
+                class="sc-kvZOFW dWodfG"
               >
                 <li>
                   <a
-                    class="sc-bbmXgH jBJcSy"
+                    class="sc-kafWEX dZZNif"
                     href="mailto:rickard.laurin@iteam.se"
                   >
                     rickard.laurin@iteam.se

--- a/src/pages/__tests__/__snapshots__/Work.spec.tsx.snap
+++ b/src/pages/__tests__/__snapshots__/Work.spec.tsx.snap
@@ -4,78 +4,78 @@ exports[`components/Work renders Work 1`] = `
 <div>
   <div>
     <div
-      class="sc-lhVmIH eaZnSP"
+      class="sc-gzOgki iAsgwX"
     >
       <div
-        class="sc-bYSBpT bdgTKs"
+        class="sc-iyvyFf fXFZjN"
       >
         <div
-          class="sc-kafWEX doqriu"
+          class="sc-elJkPf fqzjUn"
         >
           <a
-            class="sc-feJyhm bzbyYc"
+            class="sc-jtRfpW cXQLFZ"
           >
             <img
-              class="sc-iELTvK kXWcVM"
+              class="sc-kTUwUJ fgTIcp"
               data-testid="logo"
               path="test-file-stub"
             />
           </a>
           <div
-            class="sc-cmTdod gUTeYg"
+            class="sc-dqBHgY fDUITd"
           >
             <a
-              class="sc-btzYZH kmRwNW"
+              class="sc-dfVpRl uQOzH"
               aria-current="false"
             >
               Case
             </a>
             <a
-              class="sc-btzYZH kmRwNW"
+              class="sc-dfVpRl uQOzH"
               aria-current="false"
             >
               AI
             </a>
             <a
-              class="sc-btzYZH kmRwNW"
+              class="sc-dfVpRl uQOzH"
               aria-current="false"
             >
               Metod
             </a>
             <a
-              class="sc-btzYZH kmRwNW"
+              class="sc-dfVpRl uQOzH"
               aria-current="false"
             >
               Medarbetare
             </a>
             <a
-              class="sc-btzYZH kmRwNW"
+              class="sc-dfVpRl uQOzH"
               aria-current="false"
             >
               Karriär
             </a>
             <a
-              class="sc-btzYZH kmRwNW"
+              class="sc-dfVpRl uQOzH"
               aria-current="false"
             >
               Om
             </a>
             <a
-              class="sc-btzYZH kmRwNW"
+              class="sc-dfVpRl uQOzH"
               aria-current="false"
             >
               Drift & Support
             </a>
             <div
-              class="sc-jwKygS fTIVRr"
+              class="sc-gxMtzJ dqeSKx"
             />
           </div>
         </div>
         <div
-          class="sc-elJkPf kqIJd"
+          class="sc-hwwEjo fiJSKN"
         >
           <h1
-            class="sc-jtRfpW dJthJP"
+            class="sc-kPVwWT isSAXL"
           >
             <span>
               Bli en del av teamet
@@ -89,24 +89,24 @@ exports[`components/Work renders Work 1`] = `
     class="sc-iwsKbI fwFOwW"
   >
     <div
-      class="sc-hqyNC etKvRf"
+      class="sc-fYxtnH bnuCxB"
     >
       <div
-        class="sc-kvZOFW WEDpB"
+        class="sc-jnlKLf llearn"
         data-test="filter-"
         tabindex="0"
       >
         Alla
       </div>
       <div
-        class="sc-kvZOFW fQCHTO"
+        class="sc-jnlKLf hLwADf"
         data-test="filter-Stockholm"
         tabindex="0"
       >
         Stockholm
       </div>
       <div
-        class="sc-kvZOFW fQCHTO"
+        class="sc-jnlKLf hLwADf"
         data-test="filter-Göteborg"
         tabindex="0"
       >

--- a/src/schema.json
+++ b/src/schema.json
@@ -2108,9 +2108,45 @@
               "description": "",
               "args": [],
               "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "openApplicationHeader",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "openApplicationText",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null

--- a/typings/iteamse.d.ts
+++ b/typings/iteamse.d.ts
@@ -159,6 +159,12 @@ export interface HomePageQuery {
 };
 
 export interface HowWeWorkPageQuery {
+  openpositions:  Array< {
+    __typename: "OpenPosition",
+    location: string,
+    id: string,
+    title: string,
+  } >,
   pageHowWeWork:  {
     __typename: "PageHowWeWork",
     headerImage: string | null,
@@ -168,7 +174,9 @@ export interface HowWeWorkPageQuery {
     contactTitle: string,
     customersText: string,
     customersTitle: string,
-    hiringTitle: string | null,
+    hiringTitle: string,
+    openApplicationText: string,
+    openApplicationHeader: string,
     imageBleed: string,
     methodText: string,
     methodTitle: string,


### PR DESCRIPTION
**Ticket:** [#22](https://trello.com/c/u0SvG17u/22-just-nu-s%C3%B6ker-vi-block)
**Intent:** Add an open positions block on the `how-we-work` page

**Note:** Requires [this CMS PR](https://github.com/Iteam1337/iteamse-cms/pull/6)