### PR TITLE
fix: hopefully fixes helmet memory leak

### DIFF
--- a/src/server.tsx
+++ b/src/server.tsx
@@ -8,6 +8,7 @@ import fetch from 'node-fetch'
 import React from 'react'
 import { ApolloProvider, renderToStringWithData } from 'react-apollo'
 import { renderToStaticMarkup } from 'react-dom/server'
+import Helmet from 'react-helmet'
 import { StaticRouter } from 'react-router-dom'
 import serialize from 'serialize-javascript'
 import { ServerStyleSheet, ThemeProvider } from 'styled-components'
@@ -71,7 +72,19 @@ server
           />
         )
 
-        res.send(`<!doctype html>\n${renderToStaticMarkup(html)}`)
+        const staticMarkup = renderToStaticMarkup(html)
+        
+        const helmet = Helmet.renderStatic()
+        const { meta, title } = helmet
+
+        res.send(`
+          <!doctype html>
+            <head>
+              ${title.toString()}
+              ${meta.toString()}
+            </head>
+            ${staticMarkup}
+        `)
       } catch (error) {
         console.error(error)
 


### PR DESCRIPTION
**Ticket:** [#74](https://trello.com/c/ZZeUMHc7/74-fixa-react-helmet-minnesl%C3%A4ckan)
**Intent/Purpose:** 
When using [`react-helmet`](https://github.com/nfl/react-helmet#server-usage) with SSR one needs to use: `const helmet = Helmet.renderStatic()` to prevent a memory leak.

IMO, this PR (provided it fixes the issue :-)) is probably better looked at as a hot-fix. It might not be ideal to use HTML's friendliness to our advantage, but `Helmet.renderStatic()` has to (according to helmet-docs) be called after `ReactDOM.renderToStaticMarkup()`.

An idea would perhaps be to make the HTML-component return a function in which one could pass in the static helmet-object, or maybe use something like: [react-helmet-async](https://github.com/staylor/react-helmet-async/)

**How to test (optional):** ask @sebastianandreasson (but there's a branch at iteam-cms with a cacheproxy and then run a script similar to
```
const http = require('http')

const REQUESTS_PER_SECOND = 10
const HOST = 'http://localhost:3000'

const get = () => http.get(HOST)

setInterval(get, 1000 / REQUESTS_PER_SECOND)
```
and observe the memory usage on the iteamse node-client.

* [x] `npm test`
* [x] `npm run lint`
* [ ] `npm run cypress` (optional)
