### PR TITLE
fix: change the og-specific meta-tags to its correct syntax

### DIFF
--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -66,11 +66,11 @@ export class About extends React.Component {
             <>
               <Helmet>
                 <title>Iteam | Om oss</title>
-                <meta name="og:title" content="Iteam | Om oss" />
-                <meta name="twitter:title" content="Iteam | Om oss" />
+                <meta property="og:title" content="Iteam | Om oss" />
+                <meta property="twitter:title" content="Iteam | Om oss" />
                 {pageAboutUs.headerImage && (
                   <meta
-                    name="og:image"
+                    property="og:image"
                     content={`https:${pageAboutUs.headerImage}`}
                   />
                 )}

--- a/src/pages/Ai.tsx
+++ b/src/pages/Ai.tsx
@@ -44,11 +44,11 @@ export class Ai extends React.Component {
             <>
               <Helmet>
                 <title>Iteam | AI</title>
-                <meta name="og:title" content="Iteam | AI" />
-                <meta name="twitter:title" content="Iteam | AI" />
+                <meta property="og:title" content="Iteam | AI" />
+                <meta property="twitter:title" content="Iteam | AI" />
                 {pageAi.headerImage && (
                   <meta
-                    name="og:image"
+                    property="og:image"
                     content={`https:${pageAi.headerImage}`}
                   />
                 )}

--- a/src/pages/Case.tsx
+++ b/src/pages/Case.tsx
@@ -66,14 +66,14 @@ export class CasePage extends React.Component<
             <>
               <Helmet>
                 <title>Iteam | {workCase.title}</title>
-                <meta name="og:title" content={`Iteam | ${workCase.title}`} />
+                <meta property="og:title" content={`Iteam | ${workCase.title}`} />
                 <meta
-                  name="twitter:title"
+                  property="twitter:title"
                   content={`Iteam | ${workCase.title}`}
                 />
                 {workCase.casePageBackgroundImage && (
                   <meta
-                    name="og:image"
+                    property="og:image"
                     content={`https:${workCase.casePageBackgroundImage}`}
                   />
                 )}

--- a/src/pages/Cases.tsx
+++ b/src/pages/Cases.tsx
@@ -109,16 +109,16 @@ export class CasePage extends React.Component {
               <Helmet>
                 <title>Iteam | Case</title>
                 <meta
-                  name="og:title"
+                  property="og:title"
                   content="Iteam | Case"
                 />
                 <meta
-                  name="twitter:title"
+                  property="twitter:title"
                   content="Iteam | Case"
                 />
                 {pageCases.headerImage && (
                   <meta
-                    name="og:image"
+                    property="og:image"
                     content={`https:${pageCases.headerImage}`}
                   />
                 )}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -131,8 +131,8 @@ export class Home extends React.Component {
       <>
         <Helmet>
           <title>Iteam - There's a better way</title>
-          <meta name="og:title" content="Iteam - There's a better way" />
-          <meta name="twitter:title" content="Iteam - There's a better way" />
+          <meta property="og:title" content="Iteam - There's a better way" />
+          <meta property="twitter:title" content="Iteam - There's a better way" />
         </Helmet>
 
         <HomeQuery query={HOME_PAGE_QUERY}>

--- a/src/pages/HowWeWork.tsx
+++ b/src/pages/HowWeWork.tsx
@@ -60,11 +60,11 @@ export class HowWeWork extends React.Component {
             <>
               <Helmet>
                 <title>Iteam | Hur vi jobbar</title>
-                <meta name="og:title" content="Iteam | Hur vi jobbar" />
-                <meta name="twitter:title" content="Iteam | Hur vi jobbar" />
+                <meta property="og:title" content="Iteam | Hur vi jobbar" />
+                <meta property="twitter:title" content="Iteam | Hur vi jobbar" />
                 {pageHowWeWork.headerImage && (
                   <meta
-                    name="og:image"
+                    property="og:image"
                     content={`https:${pageHowWeWork.headerImage}`}
                   />
                 )}

--- a/src/pages/OpenPosition.tsx
+++ b/src/pages/OpenPosition.tsx
@@ -69,20 +69,20 @@ export class OpenPosition extends React.Component<
                   }
                 </title>
                 <meta
-                  name="og:title"
+                  property="og:title"
                   content={`Iteam | ${pageOpenPosition.headerText1} | ${
                     pageOpenPosition.headerText2
                   }`}
                 />
                 <meta
-                  name="twitter:title"
+                  property="twitter:title"
                   content={`Iteam | ${pageOpenPosition.headerText1} | ${
                     pageOpenPosition.headerText2
                   }`}
                 />
                 {pageOpenPosition.headerImage && (
                   <meta
-                    name="og:image"
+                    property="og:image"
                     content={`https:${pageOpenPosition.headerImage}`}
                   />
                 )}

--- a/src/pages/Ops.tsx
+++ b/src/pages/Ops.tsx
@@ -39,8 +39,8 @@ export class Operations extends React.Component {
             <>
               <Helmet>
                 <title>Iteam | Operations</title>
-                <meta name="og:title" content="Iteam | Operations" />
-                <meta name="twitter:title" content="Iteam | Operations" />
+                <meta property="og:title" content="Iteam | Operations" />
+                <meta property="twitter:title" content="Iteam | Operations" />
               </Helmet>
               <Header
                 backgroundImage={pageOps.headerImage}

--- a/src/pages/Team.tsx
+++ b/src/pages/Team.tsx
@@ -50,11 +50,11 @@ export class TeamPage extends React.Component {
             <>
               <Helmet>
                 <title>Iteam | Medarbetare</title>
-                <meta name="og:title" content="Iteam | Medarbetare" />
-                <meta name="twitter:title" content="Iteam | Medarbetare" />
+                <meta property="og:title" content="Iteam | Medarbetare" />
+                <meta property="twitter:title" content="Iteam | Medarbetare" />
                 {pageTeam.headerImage && (
                   <meta
-                    name="og:image"
+                    property="og:image"
                     content={`https:${pageTeam.headerImage}`}
                   />
                 )}

--- a/src/pages/TeamMember.tsx
+++ b/src/pages/TeamMember.tsx
@@ -69,14 +69,14 @@ export class TeamMemberPage extends React.Component<
             <>
               <Helmet>
                 <title>Iteam | {teamMember.name}</title>
-                <meta name="og:title" content={`Iteam | ${teamMember.name}`} />
+                <meta property="og:title" content={`Iteam | ${teamMember.name}`} />
                 <meta
-                  name="twitter:title"
+                  property="twitter:title"
                   content={`Iteam | ${teamMember.name}`}
                 />
                 {teamMember.headerImage && (
                   <meta
-                    name="og:image"
+                    property="og:image"
                     content={`https:${teamMember.headerImage}`}
                   />
                 )}

--- a/src/pages/Work.tsx
+++ b/src/pages/Work.tsx
@@ -50,11 +50,11 @@ export class Work extends React.Component {
             <>
               <Helmet>
                 <title>Iteam | Jobba hos oss</title>
-                <meta name="og:title" content="Iteam | Jobba hos oss" />
-                <meta name="twitter:title" content="Iteam | Jobba hos oss" />
+                <meta property="og:title" content="Iteam | Jobba hos oss" />
+                <meta property="twitter:title" content="Iteam | Jobba hos oss" />
                 {pageWork.headerImage && (
                   <meta
-                    name="og:image"
+                    property="og:image"
                     content={`https:${pageWork.headerImage}`}
                   />
                 )}


### PR DESCRIPTION
**Ticket:** [#89](https://trello.com/c/K3Rq7Kv7/89-n%C3%A4r-man-delar-tex-career-sidan-via-facebook-verkar-inte-og-image-tagen-alltid-anv%C3%A4ndas-som-thumbnail)
**Intent/Purpose:**
The og-metas are supposed to use the `meta property` syntax instead of `meta name` or they wouldn't take effect.

* [x] `npm test`
* [x] `npm run lint`
* [ ] `npm run cypress` (optional)
