### PR TITLE
fix: message one and two on separate rows in header

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -79,13 +79,15 @@ const Message =
     padding: 0.2rem 0.6rem;
   }
 
-  &:not(:last-of-type) {
-    margin-bottom: 5px;
-  }
-
   @media (min-width: 1025px) {
     width: auto;
     line-height: 1.4;
+  }
+`
+
+const MessageLine = styled.span`
+  &:not(:last-of-type) {
+    margin-bottom: 5px;
   }
 `
 
@@ -103,11 +105,15 @@ const Header: React.SFC<HeaderProps> = ({
         <Content>
           <Navigation />
           <MessageRow>
-            {messageOne && (
+            {(messageOne || messageTwo) && (
               <Message bgColor={backgroundColor}>
-                <span>
-                  {messageOne} {messageTwo}
-                </span>
+                {messageOne && <MessageLine>{messageOne}</MessageLine>}
+                {messageTwo && (
+                  <>
+                    <br />
+                    <MessageLine>{messageTwo}</MessageLine>
+                  </>
+                )}
               </Message>
             )}
           </MessageRow>

--- a/src/components/Header/__tests__/__snapshots__/Header.spec.tsx.snap
+++ b/src/components/Header/__tests__/__snapshots__/Header.spec.tsx.snap
@@ -69,10 +69,17 @@ exports[`components/Header renders Header 1`] = `
           class="Header__MessageRow-sc-1ofdv2r-1 indJOe"
         >
           <h1
-            class="H1-sc-1k64xg2-0 sc-kkGfuU kxsLEW"
+            class="H1-sc-1k64xg2-0 sc-kkGfuU kDnXHl"
           >
-            <span>
+            <span
+              class="Header__MessageLine-sc-1ofdv2r-2 hcZgwB"
+            >
               Vi digitaliserar företag och organisationer
+            </span>
+            <br />
+            <span
+              class="Header__MessageLine-sc-1ofdv2r-2 hcZgwB"
+            >
               genom strategi, kod och kultur
             </span>
           </h1>

--- a/src/pages/TeamMember.tsx
+++ b/src/pages/TeamMember.tsx
@@ -37,7 +37,7 @@ export const TEAM_MEMBER_PAGE_QUERY = gql`
 `
 
 const TeamMember = styled.div`
-  h1:first-of-type {
+  h1 span:first-of-type {
     font-weight: 300;
   }
 `

--- a/src/pages/__tests__/__snapshots__/About.spec.tsx.snap
+++ b/src/pages/__tests__/__snapshots__/About.spec.tsx.snap
@@ -69,10 +69,17 @@ exports[`components/About renders About 1`] = `
           class="Header__MessageRow-sc-1ofdv2r-1 indJOe"
         >
           <h1
-            class="H1-sc-1k64xg2-0 sc-kkGfuU clBDyh"
+            class="H1-sc-1k64xg2-0 sc-kkGfuU kTbLSL"
           >
-            <span>
+            <span
+              class="Header__MessageLine-sc-1ofdv2r-2 hcZgwB"
+            >
               Vi skapades ur en vilja att skapa värde,
+            </span>
+            <br />
+            <span
+              class="Header__MessageLine-sc-1ofdv2r-2 hcZgwB"
+            >
               ha kul och göra något bra
             </span>
           </h1>

--- a/src/pages/__tests__/__snapshots__/Cases.spec.tsx.snap
+++ b/src/pages/__tests__/__snapshots__/Cases.spec.tsx.snap
@@ -69,10 +69,17 @@ exports[`components/Cases renders Cases 1`] = `
           class="Header__MessageRow-sc-1ofdv2r-1 indJOe"
         >
           <h1
-            class="H1-sc-1k64xg2-0 sc-kkGfuU clBDyh"
+            class="H1-sc-1k64xg2-0 sc-kkGfuU kTbLSL"
           >
-            <span>
+            <span
+              class="Header__MessageLine-sc-1ofdv2r-2 hcZgwB"
+            >
               Några exempel på
+            </span>
+            <br />
+            <span
+              class="Header__MessageLine-sc-1ofdv2r-2 hcZgwB"
+            >
               sådant vi gjort
             </span>
           </h1>

--- a/src/pages/__tests__/__snapshots__/HowWeWork.spec.tsx.snap
+++ b/src/pages/__tests__/__snapshots__/HowWeWork.spec.tsx.snap
@@ -69,9 +69,11 @@ exports[`components/HowWeWork renders HowWeWork 1`] = `
           class="Header__MessageRow-sc-1ofdv2r-1 indJOe"
         >
           <h1
-            class="H1-sc-1k64xg2-0 sc-kkGfuU dBAbrk"
+            class="H1-sc-1k64xg2-0 sc-kkGfuU hAhygW"
           >
-            <span>
+            <span
+              class="Header__MessageLine-sc-1ofdv2r-2 hcZgwB"
+            >
               Så här jobbar vi 
             </span>
           </h1>

--- a/src/pages/__tests__/__snapshots__/Offers.spec.tsx.snap
+++ b/src/pages/__tests__/__snapshots__/Offers.spec.tsx.snap
@@ -69,9 +69,11 @@ exports[`components/Offers renders Offers 1`] = `
           class="Header__MessageRow-sc-1ofdv2r-1 indJOe"
         >
           <h1
-            class="H1-sc-1k64xg2-0 sc-kkGfuU clBDyh"
+            class="H1-sc-1k64xg2-0 sc-kkGfuU kTbLSL"
           >
-            <span>
+            <span
+              class="Header__MessageLine-sc-1ofdv2r-2 hcZgwB"
+            >
               Våra erbjudanden
             </span>
           </h1>

--- a/src/pages/__tests__/__snapshots__/OpenPosition.spec.tsx.snap
+++ b/src/pages/__tests__/__snapshots__/OpenPosition.spec.tsx.snap
@@ -69,10 +69,17 @@ exports[`components/OpenPosition renders OpenPosition 1`] = `
           class="Header__MessageRow-sc-1ofdv2r-1 indJOe"
         >
           <h1
-            class="H1-sc-1k64xg2-0 sc-kkGfuU dBAbrk"
+            class="H1-sc-1k64xg2-0 sc-kkGfuU hAhygW"
           >
-            <span>
+            <span
+              class="Header__MessageLine-sc-1ofdv2r-2 hcZgwB"
+            >
               UX Designer
+            </span>
+            <br />
+            <span
+              class="Header__MessageLine-sc-1ofdv2r-2 hcZgwB"
+            >
               Stockholm
             </span>
           </h1>

--- a/src/pages/__tests__/__snapshots__/Ops.spec.tsx.snap
+++ b/src/pages/__tests__/__snapshots__/Ops.spec.tsx.snap
@@ -69,9 +69,11 @@ exports[`components/Ops renders Ops 1`] = `
           class="Header__MessageRow-sc-1ofdv2r-1 indJOe"
         >
           <h1
-            class="H1-sc-1k64xg2-0 sc-kkGfuU iULgpw"
+            class="H1-sc-1k64xg2-0 sc-kkGfuU cYXHVS"
           >
-            <span>
+            <span
+              class="Header__MessageLine-sc-1ofdv2r-2 hcZgwB"
+            >
               Drift och support
             </span>
           </h1>

--- a/src/pages/__tests__/__snapshots__/Team.spec.tsx.snap
+++ b/src/pages/__tests__/__snapshots__/Team.spec.tsx.snap
@@ -69,9 +69,11 @@ exports[`components/Team renders Team 1`] = `
           class="Header__MessageRow-sc-1ofdv2r-1 indJOe"
         >
           <h1
-            class="H1-sc-1k64xg2-0 sc-kkGfuU dBAbrk"
+            class="H1-sc-1k64xg2-0 sc-kkGfuU hAhygW"
           >
-            <span>
+            <span
+              class="Header__MessageLine-sc-1ofdv2r-2 hcZgwB"
+            >
               Det är vi som är Iteam
             </span>
           </h1>
@@ -278,9 +280,11 @@ exports[`components/Team should handle changing location using keyboard 1`] = `
           class="Header__MessageRow-sc-1ofdv2r-1 indJOe"
         >
           <h1
-            class="H1-sc-1k64xg2-0 sc-kkGfuU dBAbrk"
+            class="H1-sc-1k64xg2-0 sc-kkGfuU hAhygW"
           >
-            <span>
+            <span
+              class="Header__MessageLine-sc-1ofdv2r-2 hcZgwB"
+            >
               Det är vi som är Iteam
             </span>
           </h1>
@@ -487,9 +491,11 @@ exports[`components/Team should handle changing location using mouse 1`] = `
           class="Header__MessageRow-sc-1ofdv2r-1 indJOe"
         >
           <h1
-            class="H1-sc-1k64xg2-0 sc-kkGfuU dBAbrk"
+            class="H1-sc-1k64xg2-0 sc-kkGfuU hAhygW"
           >
-            <span>
+            <span
+              class="Header__MessageLine-sc-1ofdv2r-2 hcZgwB"
+            >
               Det är vi som är Iteam
             </span>
           </h1>
@@ -696,9 +702,11 @@ exports[`components/Team should not change using keyboard if not enter or space 
           class="Header__MessageRow-sc-1ofdv2r-1 indJOe"
         >
           <h1
-            class="H1-sc-1k64xg2-0 sc-kkGfuU dBAbrk"
+            class="H1-sc-1k64xg2-0 sc-kkGfuU hAhygW"
           >
-            <span>
+            <span
+              class="Header__MessageLine-sc-1ofdv2r-2 hcZgwB"
+            >
               Det är vi som är Iteam
             </span>
           </h1>

--- a/src/pages/__tests__/__snapshots__/TeamMember.spec.tsx.snap
+++ b/src/pages/__tests__/__snapshots__/TeamMember.spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`components/Team renders TeamMember 1`] = `
 <div>
   <div
-    class="TeamMember-sc-1dabmxm-0 GfkES"
+    class="TeamMember-sc-1dabmxm-0 essGSG"
   >
     <div>
       <div
@@ -72,10 +72,17 @@ exports[`components/Team renders TeamMember 1`] = `
             class="Header__MessageRow-sc-1ofdv2r-1 indJOe"
           >
             <h1
-              class="H1-sc-1k64xg2-0 sc-kkGfuU dBAbrk"
+              class="H1-sc-1k64xg2-0 sc-kkGfuU hAhygW"
             >
-              <span>
+              <span
+                class="Header__MessageLine-sc-1ofdv2r-2 hcZgwB"
+              >
                 Rickard Laurin
+              </span>
+              <br />
+              <span
+                class="Header__MessageLine-sc-1ofdv2r-2 hcZgwB"
+              >
                 Webbutvecklare
               </span>
             </h1>

--- a/src/pages/__tests__/__snapshots__/Work.spec.tsx.snap
+++ b/src/pages/__tests__/__snapshots__/Work.spec.tsx.snap
@@ -69,9 +69,11 @@ exports[`components/Work renders Work 1`] = `
           class="Header__MessageRow-sc-1ofdv2r-1 indJOe"
         >
           <h1
-            class="H1-sc-1k64xg2-0 sc-kkGfuU iULgpw"
+            class="H1-sc-1k64xg2-0 sc-kkGfuU cYXHVS"
           >
-            <span>
+            <span
+              class="Header__MessageLine-sc-1ofdv2r-2 hcZgwB"
+            >
               Bli en del av teamet
             </span>
           </h1>


### PR DESCRIPTION
**Ticket:** N/A
**Intent/Purpose:** Split the header messages into two separate lines. Mainly because the name and occupation should be on two lines for a team member.
**How to test (optional):** 

* [x] `npm test`
* [x] `npm run lint`
* [ ] `npm run cypress` (optional)
