### PR TITLE
feat: remove open position image divider

### DIFF
--- a/src/pages/OpenPosition.tsx
+++ b/src/pages/OpenPosition.tsx
@@ -5,7 +5,6 @@ import Helmet from 'react-helmet-async'
 import { RouteComponentProps, withRouter } from 'react-router-dom'
 import { OpenPositionPageQuery } from '../../typings/iteamse'
 import Block from '../components/Blocks/Block'
-import ImageBleed from '../components/Blocks/ImageBleed'
 import Breadcrumbs from '../components/Breadcrumbs/Breadcrumbs'
 import GridColumn from '../components/Grid/GridColumn'
 import Header from '../components/Header/Header'
@@ -25,7 +24,6 @@ export const OPEN_POSITION_PAGE_QUERY = gql`
       bonusKnowledge
       bonusKnowledgeTitle
       contactTitle
-      contentImage
       knowledge
       knowledgeTitle
       location
@@ -108,8 +106,6 @@ export class OpenPosition extends React.Component<
                 <Block title={pageOpenPosition.bonusKnowledgeTitle}>
                   {pageOpenPosition.bonusKnowledge}
                 </Block>
-
-                <ImageBleed image={pageOpenPosition.contentImage} />
 
                 <Block title={pageOpenPosition.aboutUsTitle}>
                   {pageOpenPosition.aboutUs}

--- a/src/pages/__tests__/__snapshots__/OpenPosition.spec.tsx.snap
+++ b/src/pages/__tests__/__snapshots__/OpenPosition.spec.tsx.snap
@@ -247,10 +247,6 @@ exports[`components/OpenPosition renders OpenPosition 1`] = `
         </div>
       </div>
     </div>
-    <img
-      src="//images.ctfassets.net/rj4r6yfcesw5/62hgzE8G3ueMa2YSEuG4og/db2b643db6041f9d26936bc2d6006607/bleed_howwework.jpg"
-      class="ImageBleed__ImageContainer-sc-1qgs15y-0 dtCUjJ"
-    />
     <div
       class="react-reveal"
       style="opacity: 1;"


### PR DESCRIPTION
**Ticket:** [#115](https://trello.com/c/PgGopd74/115-karri%C3%A4r-annonssida-g%C3%B6r-ans%C3%B6k-tydligare)
**Intent/Purpose:** A purpose/intent of the code change.
Remove divider image from career page
**How to test (optional):** A description of how to test this PR (if not obvious).
go to any open position and take a look :) 

* [x] `npm test`
* [ ] `npm run lint`
* [ ] `npm run cypress` (optional)
